### PR TITLE
Travis Settings, Security Update, default modules:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,16 @@ node_js:
   - lts/*
   - node
 
+stages:
+  - test
+  - name: release
+    if: branch = master && type != pull_request
+
 jobs:
   include:
     - stage: release
       node_js: node
+      script: skip
       deploy:
         provider: script
         skip_cleanup: true

--- a/default-settings.js
+++ b/default-settings.js
@@ -1,4 +1,7 @@
 module.exports = {
+  env: {
+    modules: false
+  },
   extractFormatMessage: {
     outFile: "locales/en.json"
   },

--- a/default-settings.js
+++ b/default-settings.js
@@ -1,7 +1,14 @@
+const env = {
+  modules: false
+};
+
+// This allows jest to function normally
+if (process.env.NODE_ENV === 'test') {
+  env.modules = "auto";
+}
+
 module.exports = {
-  env: {
-    modules: false
-  },
+  env,
   extractFormatMessage: {
     outFile: "locales/en.json"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7603,9 +7603,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
     "merge-stream": {


### PR DESCRIPTION
- optimize release step
  - skip `npm test` during `release` job, as the `test` stage is guaranteed to run before `release`
  - exclude `release` job from being run on non-master builds
- Update `package-lock.json` to address security vulnerability
- Add default config for `@babel/preset-env` to not transform esmodule import/export statements
  - Closes #9 