### PR TITLE
Use `@babel/runtime-corejs2`

### DIFF
--- a/default-settings.js
+++ b/default-settings.js
@@ -1,5 +1,6 @@
 const env = {
-  modules: false
+  modules: false,
+  targets: { id: '11' }
 };
 
 // This allows jest to function normally

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(context, options = {}) {
     require('@babel/plugin-proposal-class-properties'),
     require('@babel/plugin-proposal-object-rest-spread'),
     [require('babel-plugin-transform-react-remove-prop-types'), { mode: 'wrap' }],
-    require('@babel/plugin-transform-runtime')
+    [require('@babel/plugin-transform-runtime'), { corejs: 2 }]
   ];
 
   if (extractFormatMessage !== false) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -871,14 +871,20 @@
         "@babel/plugin-transform-react-jsx-source": "^7.0.0"
       }
     },
-    "@babel/runtime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+    "@babel/runtime-corejs2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.2.0.tgz",
+      "integrity": "sha512-kPfmKoRI8Hpo5ZJGACWyrc9Eq1j3ZIUpUAQT2yH045OuYpccFJ9kYA/eErwzOM2jeBG1sC8XX1nl1EArtuM8tg==",
       "requires": {
+        "core-js": "^2.5.7",
         "regenerator-runtime": "^0.12.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
         "regenerator-runtime": {
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/plugin-transform-runtime": "^7.1.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "@babel/runtime": "^7.0.0",
+    "@babel/runtime-corejs2": "^7.2.0",
     "babel-plugin-extract-format-message": "^6.1.0",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-styled-components": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "jest": {
     "testEnvironment": "node"
   },
+  "peerDependencies": {
+    "@babel/runtime-corejs2": "^7.2.0"
+  },
   "dependencies": {
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",


### PR DESCRIPTION
The helpers provided by @babel/runtime make references to `Symbol` and `Array.from`, which are not supported by IE11. Using `@babel/runtime-corejs2` will provided the necessary polyfills not only for user code transformed by babel but the helpers in this runtime make the correct references to `core-js` as well.