### PR TITLE
useBuiltIns: 'usage'

### DIFF
--- a/default-settings.js
+++ b/default-settings.js
@@ -1,6 +1,7 @@
 const env = {
   modules: false,
-  targets: { id: '11' }
+  targets: { ie: '11' },
+  useBuiltIns: 'usage'
 };
 
 // This allows jest to function normally


### PR DESCRIPTION
Not all IE 11 polyfills get added to resulting builds as originally intended. useBuiltIns will ensure all necessary polyfills such as Array.find get added to resulting builds.