### PR TITLE
Update React 17 JSX transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,10 @@ module.exports = function(context, options = {}) {
   ];
 
   if (react !== false) {
-    presets.push(require('@babel/preset-react'));
+    presets.push([
+      require('@babel/preset-react'),
+      Object.assign({}, defaultSettings.react, typeof react === 'boolean' ? {} : react || {})
+    ]);
   }
 
   const plugins = [


### PR DESCRIPTION
Enable the new JSX transform. Allows us to not have to include `React` in every js file.

https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#manual-babel-setup